### PR TITLE
Remediate Rails audit findings: tests, export presenters, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,21 @@ On-Hold                 | `on-hold`          | `pending`
 
 The integration respects Spree's `auto_capture_on_dispatch` setting. When enabled in your Spree store, pending payments are captured automatically before a shipment is marked as shipped. If a payment capture fails, an error is returned to ShipStation (HTTP 400), preventing the shipment from being marked as shipped until the issue is resolved.
 
+Payment capture happens **synchronously** within the shipnotify webhook request (inside a database transaction) so that a shipment is never marked as shipped against an uncaptured payment. ShipStation automatically retries failed webhook deliveries, and the operation is designed to be safe to repeat: a shipment that is already `shipped` is not shipped again, and only still-pending payments are captured. If your payment gateway is slow, be aware that the capture round-trip occurs in the request cycle.
+
 ### Pagination
 
 The export endpoint returns up to **50 shipments per page**. ShipStation handles pagination automatically using the `page` query parameter.
+
+## Security considerations
+
+- **Serve the endpoints over HTTPS.** Both `/shipstation` endpoints authenticate with HTTP Basic Auth, which transmits the configured username and password (base64-encoded) on every request. Always terminate these requests over TLS in production so the credentials are not exposed in transit. Credentials are compared in constant time to avoid timing attacks.
+- **Consider rate limiting.** The gem does not throttle authentication attempts. If you want brute-force protection, add it at the application or edge layer (for example, [`rack-attack`](https://github.com/rack/rack-attack)). The enforced credential length (10–30 character username, 20–60 character complex password) already makes guessing impractical.
+- **Response codes.** When no active ShipStation integration is configured, the endpoints respond with `404` before authentication is checked; a configured-but-unauthenticated request responds with `401`. This is intentional, but be aware it reveals whether the integration is configured.
+
+## Performance
+
+The export query eager-loads its association graph to avoid N+1 queries. The `exportable` scope filters shipments by `state` and orders them by `updated_at`, joining and filtering orders by their `updated_at`. The gem ships no migrations of its own; on large stores, ensure the relevant Spree core columns (`spree_shipments.state`, `spree_shipments.updated_at`, `spree_orders.updated_at`) are adequately indexed in your application's database.
 
 ## Usage
 

--- a/app/controllers/spree/shipstation_controller.rb
+++ b/app/controllers/spree/shipstation_controller.rb
@@ -14,7 +14,6 @@ module Spree
       @pagy, @shipments = pagy(
         current_store.shipments
           .exportable
-          .includes(:order, inventory_units: {line_item: {variant: [:product, :images, {option_values: :option_type}]}})
           .between(date_param(:start_date), date_param(:end_date)),
         page: params[:page],
         items: 50

--- a/app/helpers/spree_shipstation/export_helper.rb
+++ b/app/helpers/spree_shipstation/export_helper.rb
@@ -6,46 +6,36 @@ module SpreeShipstation
   module ExportHelper
     DATE_FORMAT = "%m/%d/%Y %H:%M"
 
-    def self.address(xml, order, type)
-      address = order.public_send("#{type}_address")
-      return unless address
-
-      tag_name = "#{type.to_s.camelize}To"
-
-      xml.tag!(tag_name) do
-        xml.Name name_from(address)
-        xml.Company address.company
-
-        if type == :ship
-          xml.Address1 address.address1
-          xml.Address2 address.address2
-          xml.City address.city
-          xml.State state_from(address)
-          xml.PostalCode address.zipcode
-          xml.Country address.country&.iso
-        end
-
-        xml.Phone address.phone
-      end
+    def self.bill_address(xml, address)
+      render_address(xml, address, "BillTo", include_street: false)
     end
 
-    def self.weight(variant)
-      value = variant.weight || 0.0
-
-      case variant.weight_unit
-      when "lb"
-        [value.to_f, "Pounds"]
-      when "oz"
-        [value.to_f, "Ounces"]
-      when "kg"
-        [(value * 1000).to_f, "Grams"]
-      else
-        [value.to_f, "Grams"]
-      end
+    def self.ship_address(xml, address)
+      render_address(xml, address, "ShipTo", include_street: true)
     end
 
     class << self
       private
+
+      def render_address(xml, address, tag_name, include_street:)
+        return unless address
+
+        xml.tag!(tag_name) do
+          xml.Name name_from(address)
+          xml.Company address.company
+
+          if include_street
+            xml.Address1 address.address1
+            xml.Address2 address.address2
+            xml.City address.city
+            xml.State state_from(address)
+            xml.PostalCode address.zipcode
+            xml.Country address.country&.iso
+          end
+
+          xml.Phone address.phone
+        end
+      end
 
       def name_from(address)
         return address.name if address.respond_to?(:name)

--- a/app/models/spree/integrations/shipstation.rb
+++ b/app/models/spree/integrations/shipstation.rb
@@ -3,16 +3,14 @@
 module Spree
   module Integrations
     class Shipstation < Spree::Integration
-      # --- Username ---
       preference :username, :string
 
-      # 1. Base requirements: Presence and Length
       validates :preferred_username,
         presence: true,
         length: {minimum: 10, maximum: 30}
 
-      # 2. Requirement: Safe Characters Only (Basic Auth Compatible)
-      # Allows: a-z, A-Z, 0-9, ., _, @, +, -
+      # Restrict to characters that are safe to send in an HTTP Basic Auth header:
+      # a-z, A-Z, 0-9, and . _ @ + -
       validates :preferred_username,
         format: {
           with: /\A[a-zA-Z0-9._@+-]+\z/,
@@ -20,15 +18,12 @@ module Spree
         },
         allow_blank: true
 
-      # --- Password ---
       preference :password, :password
 
-      # 1. Base requirements: Presence and Length
       validates :preferred_password,
         presence: true,
         length: {minimum: 20, maximum: 60}
 
-      # 2. Requirement: At least one Special Character
       validates :preferred_password,
         format: {
           with: /[!@#$%^&*(),.?":{}|<>]/,
@@ -36,7 +31,6 @@ module Spree
         },
         allow_blank: true
 
-      # 3. Requirement: At least one Uppercase Letter
       validates :preferred_password,
         format: {
           with: /[A-Z]/,
@@ -44,10 +38,9 @@ module Spree
         },
         allow_blank: true
 
-      # 4. Requirement: At least one Number
       validates :preferred_password,
         format: {
-          with: /\d/, # \d matches any digit 0-9
+          with: /\d/,
           message: Spree.t("admin.integrations.shipstation.must_contain_at_least_one_number")
         },
         allow_blank: true

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -8,6 +8,7 @@ module Spree
           .merge(::Spree::Order.complete)
           .where(state: "ready")
           .order(:updated_at)
+          .includes(:order, inventory_units: {line_item: {variant: [:product, :images, {option_values: :option_type}]}})
       }
 
       base.scope :between, lambda { |from, to|

--- a/app/presenters/spree_shipstation/export/item_presenter.rb
+++ b/app/presenters/spree_shipstation/export/item_presenter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module SpreeShipstation
+  module Export
+    # Shapes a shipment line item (a line item plus its inventory units) into the
+    # values ShipStation's export XML expects for an <Item>.
+    class ItemPresenter
+      attr_reader :line_item, :units
+
+      def initialize(line_item, units)
+        @line_item = line_item
+        @units = units
+      end
+
+      def variant
+        @variant ||= line_item.variant
+      end
+
+      def sku
+        variant.sku
+      end
+
+      def name
+        [variant.product.name, variant.options_text].reject(&:blank?).join(" ")
+      end
+
+      # The Spree::Image to advertise, or nil. URL generation stays in the view
+      # because it depends on Rails route/URL helpers.
+      def image
+        variant.images.first || variant.product.master.images.first
+      end
+
+      def weight
+        Weight.from_variant(variant)
+      end
+
+      def quantity
+        units.size
+      end
+
+      def unit_price
+        line_item.price
+      end
+
+      def option_values
+        variant.option_values
+      end
+    end
+  end
+end

--- a/app/presenters/spree_shipstation/export/order_presenter.rb
+++ b/app/presenters/spree_shipstation/export/order_presenter.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module SpreeShipstation
+  module Export
+    # Shapes a single Spree::Shipment into the values ShipStation's export XML
+    # expects, keeping data-massaging logic out of the Builder template.
+    #
+    # Note: ShipStation models one "Order" per shipment, so most order-level
+    # fields are derived from `shipment.order` while identifiers come from the
+    # shipment itself (mirroring the <OrderNumber> = shipment.number contract).
+    class OrderPresenter
+      attr_reader :shipment
+
+      def initialize(shipment)
+        @shipment = shipment
+      end
+
+      def order
+        shipment.order
+      end
+
+      def order_id
+        shipment.id
+      end
+
+      def order_number
+        shipment.number
+      end
+
+      def order_status
+        shipment.state
+      end
+
+      def order_date
+        format_date(order.completed_at)
+      end
+
+      def last_modified
+        format_date([order.completed_at, shipment.updated_at].compact.max)
+      end
+
+      def shipping_method_name
+        shipment.shipping_method&.name
+      end
+
+      def order_total
+        order.total
+      end
+
+      def tax_total
+        order.tax_total
+      end
+
+      def ship_total
+        order.ship_total
+      end
+
+      def custom_field_1
+        order.number
+      end
+
+      def customer_code
+        order.email&.slice(0, 50)
+      end
+
+      def bill_address
+        order.bill_address
+      end
+
+      def ship_address
+        order.ship_address
+      end
+
+      def items
+        shipment.inventory_units.group_by(&:line_item).filter_map do |line_item, units|
+          next unless line_item.variant
+
+          ItemPresenter.new(line_item, units)
+        end
+      end
+
+      private
+
+      def format_date(time)
+        time&.strftime(SpreeShipstation::ExportHelper::DATE_FORMAT)
+      end
+    end
+  end
+end

--- a/app/presenters/spree_shipstation/export/weight.rb
+++ b/app/presenters/spree_shipstation/export/weight.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module SpreeShipstation
+  module Export
+    # Value object converting a Spree::Variant's weight into the
+    # (value, unit-label) pair ShipStation's export XML expects.
+    #
+    # ShipStation accepts Pounds, Ounces, and Grams; any unrecognised Spree
+    # weight unit (including a missing weight) falls back to Grams.
+    class Weight
+      attr_reader :value, :units
+
+      def initialize(value:, units:)
+        @value = value
+        @units = units
+      end
+
+      def self.from_variant(variant)
+        amount = (variant.weight || 0.0).to_f
+
+        case variant.weight_unit
+        when "lb"
+          new(value: amount, units: "Pounds")
+        when "oz"
+          new(value: amount, units: "Ounces")
+        when "kg"
+          new(value: amount * 1000, units: "Grams")
+        else
+          new(value: amount, units: "Grams")
+        end
+      end
+
+      def ==(other)
+        other.is_a?(self.class) && value == other.value && units == other.units
+      end
+      alias_method :eql?, :==
+
+      def hash
+        [value, units].hash
+      end
+    end
+  end
+end

--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -1,58 +1,49 @@
-# frozen_string_literal: true
-
 xml.instruct!
 
 xml.Orders(pages: @pagy.pages) do
   @shipments.each do |shipment|
-    order = shipment.order
+    order = SpreeShipstation::Export::OrderPresenter.new(shipment)
 
     xml.Order do
-      xml.OrderID shipment.id
-      xml.OrderNumber shipment.number
+      xml.OrderID order.order_id
+      xml.OrderNumber order.order_number
 
-      xml.OrderDate order.completed_at&.strftime(SpreeShipstation::ExportHelper::DATE_FORMAT)
-      xml.OrderStatus shipment.state
+      xml.OrderDate order.order_date
+      xml.OrderStatus order.order_status
+      xml.LastModified order.last_modified
 
-      last_modified = [order.completed_at, shipment.updated_at].compact.max
-      xml.LastModified last_modified&.strftime(SpreeShipstation::ExportHelper::DATE_FORMAT)
-
-      xml.ShippingMethod shipment.shipping_method&.name
-      xml.OrderTotal order.total
+      xml.ShippingMethod order.shipping_method_name
+      xml.OrderTotal order.order_total
       xml.TaxAmount order.tax_total
       xml.ShippingAmount order.ship_total
-      xml.CustomField1 order.number
+      xml.CustomField1 order.custom_field_1
 
       xml.Customer do
-        xml.CustomerCode order.email&.slice(0, 50)
-        SpreeShipstation::ExportHelper.address(xml, order, :bill)
-        SpreeShipstation::ExportHelper.address(xml, order, :ship)
+        xml.CustomerCode order.customer_code
+        SpreeShipstation::ExportHelper.bill_address(xml, order.bill_address)
+        SpreeShipstation::ExportHelper.ship_address(xml, order.ship_address)
       end
 
       xml.Items do
-        shipment.inventory_units.group_by(&:line_item).each do |line, units|
-          variant = line.variant
-          next unless variant
-
-          weight_val, weight_units = SpreeShipstation::ExportHelper.weight(variant)
+        order.items.each do |item|
+          weight = item.weight
+          image = item.image
 
           xml.Item do
-            xml.SKU variant.sku
+            xml.SKU item.sku
+            xml.Name item.name
 
-            name_parts = [variant.product.name, variant.options_text]
-            xml.Name name_parts.reject(&:blank?).join(" ")
-
-            image = variant.images.first || variant.product.master.images.first
             image_url = image && url_for(image.attachment)
             xml.ImageUrl image_url if image_url
 
-            xml.Weight weight_val
-            xml.WeightUnits weight_units
-            xml.Quantity units.size
-            xml.UnitPrice line.price
+            xml.Weight weight.value
+            xml.WeightUnits weight.units
+            xml.Quantity item.quantity
+            xml.UnitPrice item.unit_price
 
-            if variant.option_values.present?
+            if item.option_values.present?
               xml.Options do
-                variant.option_values.each do |value|
+                item.option_values.each do |value|
                   xml.Option do
                     xml.Name value.option_type.presentation
                     xml.Value value.name

--- a/lib/spree_shipstation/shipment_notice.rb
+++ b/lib/spree_shipstation/shipment_notice.rb
@@ -41,6 +41,12 @@ module SpreeShipstation
     def ship_shipment
       raise MissingTrackingNumberError if shipment_tracking.blank?
 
+      # Payment capture is performed synchronously, inside the webhook request and
+      # the surrounding transaction, so a capture failure aborts the ship and is
+      # reported back to ShipStation as an error (HTTP 400) rather than silently
+      # shipping an uncaptured order. ShipStation retries failed webhooks, so the
+      # operation is written to be safe to repeat: an already-shipped shipment is
+      # not re-shipped (see below) and capture only targets still-pending payments.
       capture_pending_payments! if Spree::Config.auto_capture_on_dispatch
 
       shipment.tracking = shipment_tracking

--- a/spec/controllers/spree/shipstation_controller_spec.rb
+++ b/spec/controllers/spree/shipstation_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Spree::ShipstationController do
   render_views
 
@@ -19,7 +21,6 @@ RSpec.describe Spree::ShipstationController do
 
     context "when the authentication is invalid" do
       it "returns 401" do
-        # Method call updated to use the helper
         stub_basic_auth("some_wrong_username", "not_the_correct-password")
         create(:order_ready_to_ship, store: store)
 
@@ -29,10 +30,12 @@ RSpec.describe Spree::ShipstationController do
     end
 
     context "when the authentication is valid" do
-      it "responds with 200 OK" do
+      before do
         stub_basic_auth(ssi.preferred_username, ssi.preferred_password)
         create(:order_ready_to_ship, store: store)
+      end
 
+      it "responds with 200 OK" do
         get :export,
           params: {
             start_date: 1.day.ago.strftime("%m/%d/%Y %H:%M"),
@@ -45,9 +48,6 @@ RSpec.describe Spree::ShipstationController do
       end
 
       it "generates ShipStation-compliant XML" do
-        stub_basic_auth(ssi.preferred_username, ssi.preferred_password)
-        create(:order_ready_to_ship, store: store)
-
         get :export,
           params: {
             start_date: 100.day.ago.strftime("%m/%d/%Y %H:%M"),
@@ -56,6 +56,13 @@ RSpec.describe Spree::ShipstationController do
             page: 1
           }
 
+        expect(response.body).to pass_validation("spec/fixtures/shipstation_xml_schema.xsd")
+      end
+
+      it "ignores malformed date params and still responds successfully" do
+        get :export, params: {start_date: "not-a-date", end_date: "13/45/9999", format: :xml, page: 1}
+
+        expect(response.status).to eq(200)
         expect(response.body).to pass_validation("spec/fixtures/shipstation_xml_schema.xsd")
       end
     end
@@ -89,25 +96,24 @@ RSpec.describe Spree::ShipstationController do
     end
 
     context "when the authentication is valid" do
-      context "when the shipment can be found" do
-        it "responds with 200 OK" do
-          stub_basic_auth(ssi.preferred_username, ssi.preferred_password)
-          shipment = create(:order_ready_to_ship).shipments.first
+      before do
+        stub_basic_auth(ssi.preferred_username, ssi.preferred_password)
+      end
 
+      context "when the shipment can be found" do
+        let(:shipment) { create(:order_ready_to_ship).shipments.first }
+
+        it "responds with 200 OK" do
           post :shipnotify, params: {
             order_number: shipment.number,
             tracking_number: "123456",
             format: :xml
           }
-          shipment.reload
 
           expect(response.status).to eq(200)
         end
 
         it "updates the shipment" do
-          stub_basic_auth(ssi.preferred_username, ssi.preferred_password)
-          shipment = create(:order_ready_to_ship).shipments.first
-
           post :shipnotify, params: {
             order_number: shipment.number,
             tracking_number: "123456",
@@ -121,19 +127,27 @@ RSpec.describe Spree::ShipstationController do
             shipped_at: an_instance_of(ActiveSupport::TimeWithZone)
           )
         end
+
+        it "responds with 400 Bad Request when the tracking number is missing" do
+          post :shipnotify, params: {
+            order_number: shipment.number,
+            format: :xml
+          }
+
+          expect(response.status).to eq(400)
+          expect(shipment.reload).not_to be_shipped
+        end
       end
 
       context "when the shipment cannot be found" do
         it "responds with 400 Bad Request" do
-          stub_basic_auth(ssi.preferred_username, ssi.preferred_password)
-          shipment = create(:order_ready_to_ship).shipments.first
+          create(:order_ready_to_ship)
 
           post :shipnotify, params: {
             order_number: "ABC123",
             tracking_number: "123456",
             format: :xml
           }
-          shipment.reload
 
           expect(response.status).to eq(400)
         end

--- a/spec/helpers/spree_shipstation/export_helper_spec.rb
+++ b/spec/helpers/spree_shipstation/export_helper_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "builder"
+
+RSpec.describe SpreeShipstation::ExportHelper do
+  describe "address rendering" do
+    let(:xml) { Builder::XmlMarkup.new }
+
+    def address_double(overrides = {})
+      defaults = {
+        name: "Jane Doe",
+        company: "Acme",
+        address1: "1 Main St",
+        address2: "Apt 2",
+        city: "Springfield",
+        state: double("State", abbr: "IL"),
+        state_name: "Illinois",
+        zipcode: "12345",
+        country: double("Country", iso: "US"),
+        phone: "555-1234"
+      }
+      double("Address", defaults.merge(overrides))
+    end
+
+    describe ".ship_address" do
+      it "emits nothing when the address is missing" do
+        expect(described_class.ship_address(xml, nil)).to be_nil
+        expect(xml.target!).to eq("")
+      end
+
+      it "emits the full set of fields" do
+        described_class.ship_address(xml, address_double)
+        output = xml.target!
+
+        expect(output).to include("<ShipTo>")
+        expect(output).to include("<Name>Jane Doe</Name>")
+        expect(output).to include("<Address1>1 Main St</Address1>")
+        expect(output).to include("<City>Springfield</City>")
+        expect(output).to include("<State>IL</State>")
+        expect(output).to include("<PostalCode>12345</PostalCode>")
+        expect(output).to include("<Country>US</Country>")
+        expect(output).to include("<Phone>555-1234</Phone>")
+      end
+
+      it "falls back to the state name when no abbreviation is available" do
+        described_class.ship_address(xml, address_double(state: nil, state_name: "Illinois"))
+
+        expect(xml.target!).to include("<State>Illinois</State>")
+      end
+
+      it "falls back to full_name when the address has no name" do
+        address = double("Address",
+          company: "Acme",
+          address1: "1 Main St",
+          address2: nil,
+          city: "Springfield",
+          state: double("State", abbr: "IL"),
+          state_name: "Illinois",
+          zipcode: "12345",
+          country: double("Country", iso: "US"),
+          phone: "555-1234",
+          full_name: "Legacy Name")
+
+        described_class.ship_address(xml, address)
+
+        expect(xml.target!).to include("<Name>Legacy Name</Name>")
+      end
+    end
+
+    describe ".bill_address" do
+      it "emits nothing when the address is missing" do
+        expect(described_class.bill_address(xml, nil)).to be_nil
+        expect(xml.target!).to eq("")
+      end
+
+      it "omits street-level fields" do
+        described_class.bill_address(xml, address_double)
+        output = xml.target!
+
+        expect(output).to include("<BillTo>")
+        expect(output).to include("<Name>Jane Doe</Name>")
+        expect(output).to include("<Phone>555-1234</Phone>")
+        expect(output).not_to include("Address1")
+        expect(output).not_to include("PostalCode")
+        expect(output).not_to include("Country")
+      end
+    end
+  end
+end

--- a/spec/lib/spree_shipstation/shipment_notice_spec.rb
+++ b/spec/lib/spree_shipstation/shipment_notice_spec.rb
@@ -29,11 +29,104 @@ RSpec.describe SpreeShipstation::ShipmentNotice do
             expect_order_to_be_shipped(order)
           end
         end
+
+        context "when a pending payment cannot be captured" do
+          it "raises a PaymentError naming the payment" do
+            order = create(:completed_order_with_pending_payment)
+            payment = pending_payment_for(order)
+            allow_any_instance_of(Spree::Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
+
+            shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: "1Z1231234")
+
+            expect { shipment_notice.apply }
+              .to raise_error(SpreeShipstation::PaymentError, "Could not process payment #{payment.id}")
+          end
+
+          it "does not ship the shipment" do
+            order = create(:completed_order_with_pending_payment)
+            pending_payment_for(order)
+            allow_any_instance_of(Spree::Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
+
+            shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: "1Z1231234")
+
+            expect { shipment_notice.apply }.to raise_error(SpreeShipstation::PaymentError)
+            expect(order.shipments.first.reload).not_to be_shipped
+          end
+        end
+      end
+    end
+
+    context "when auto_capture_on_dispatch is false" do
+      before do
+        allow(Spree::Config).to receive(:auto_capture_on_dispatch).and_return(false)
+      end
+
+      it "ships an already-paid order without capturing payments" do
+        order = create(:order_ready_to_ship)
+        expect_any_instance_of(Spree::Payment).not_to receive(:capture!)
+
+        shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: "1Z1231234")
+        shipment_notice.apply
+
+        expect_order_to_be_shipped(order)
+      end
+    end
+
+    context "when the shipment cannot be found" do
+      it "raises a ShipmentNotFoundError naming the shipment number" do
+        store = create(:store, default: true)
+
+        shipment_notice = SpreeShipstation::ShipmentNotice.new(
+          shipment_number: "DOES-NOT-EXIST",
+          shipment_tracking: "1Z1231234",
+          store: store
+        )
+
+        expect { shipment_notice.apply }
+          .to raise_error(SpreeShipstation::ShipmentNotFoundError, /DOES-NOT-EXIST/)
+      end
+    end
+
+    context "when the tracking number is blank" do
+      it "raises a MissingTrackingNumberError" do
+        order = create(:order_ready_to_ship)
+
+        shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: "")
+
+        expect { shipment_notice.apply }
+          .to raise_error(SpreeShipstation::MissingTrackingNumberError, "Tracking number is required")
+      end
+    end
+
+    context "when the shipment is already shipped" do
+      it "updates the tracking number without re-shipping" do
+        order = create(:order_ready_to_ship)
+        shipment = order.shipments.first
+        shipment.ship!
+
+        expect(shipment).not_to receive(:ship!)
+        allow(order.store.shipments).to receive(:find_by).and_return(shipment)
+
+        shipment_notice = SpreeShipstation::ShipmentNotice.new(
+          shipment_number: shipment.number,
+          shipment_tracking: "1Z9999999",
+          store: order.store
+        )
+        shipment_notice.apply
+
+        expect(shipment.reload.tracking).to eq("1Z9999999")
+        expect(shipment).to be_shipped
       end
     end
   end
 
   private
+
+  # Transitions the order's existing (checkout-state) payment into the `pending`
+  # state so that `Spree::Payment.pending` returns it, exercising the capture path.
+  def pending_payment_for(order)
+    order.payments.first.tap { |payment| payment.update_column(:state, "pending") }
+  end
 
   def build_shipment_notice(shipment, shipment_tracking: "1Z1231234")
     SpreeShipstation::ShipmentNotice.new(

--- a/spec/lib/spree_shipstation_spec.rb
+++ b/spec/lib/spree_shipstation_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe SpreeShipstation do
       expect(SpreeShipstation::VERSION).to be_present
     end
   end
+
+  describe ".version" do
+    it "returns the VERSION as a Gem::Version" do
+      expect(SpreeShipstation.version).to eq(Gem::Version.new(SpreeShipstation::VERSION))
+    end
+  end
 end

--- a/spec/models/spree/integrations/shipstation_spec.rb
+++ b/spec/models/spree/integrations/shipstation_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Spree::Integrations::Shipstation do
+  let!(:store) { create(:store, default: true) }
+
+  subject(:integration) { build(:shipstation_integration) }
+
+  it "is valid with the factory defaults" do
+    expect(integration).to be_valid
+  end
+
+  describe "username validations" do
+    it "is invalid without a username" do
+      integration.preferred_username = nil
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_username]).to be_present
+    end
+
+    it "is invalid when shorter than 10 characters" do
+      integration.preferred_username = "a" * 9
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_username]).to be_present
+    end
+
+    it "is valid at the minimum length of 10 characters" do
+      integration.preferred_username = "a" * 10
+
+      expect(integration).to be_valid
+    end
+
+    it "is invalid when longer than 30 characters" do
+      integration.preferred_username = "a" * 31
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_username]).to be_present
+    end
+
+    it "is valid at the maximum length of 30 characters" do
+      integration.preferred_username = "a" * 30
+
+      expect(integration).to be_valid
+    end
+
+    it "allows the documented safe characters" do
+      integration.preferred_username = "user.name_01@host+tag-x"
+
+      expect(integration).to be_valid
+    end
+
+    it "is invalid with characters outside the safe set" do
+      integration.preferred_username = "invalid username!"
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_username]).to be_present
+    end
+  end
+
+  describe "password validations" do
+    # A baseline password that satisfies every complexity rule and the length bounds.
+    let(:valid_password) { "ValidPassword1@xxxxxx" }
+
+    it "is invalid without a password" do
+      integration.preferred_password = nil
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_password]).to be_present
+    end
+
+    it "is invalid when shorter than 20 characters" do
+      integration.preferred_password = "Short1@pass"
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_password]).to be_present
+    end
+
+    it "is invalid when longer than 60 characters" do
+      integration.preferred_password = "A1@#{"a" * 60}"
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_password]).to be_present
+    end
+
+    it "is valid when all complexity rules and length bounds are met" do
+      integration.preferred_password = valid_password
+
+      expect(integration).to be_valid
+    end
+
+    it "is invalid without a special character" do
+      integration.preferred_password = "ValidPassword1xxxxxxx"
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_password]).to be_present
+    end
+
+    it "is invalid without an uppercase letter" do
+      integration.preferred_password = "validpassword1@xxxxxx"
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_password]).to be_present
+    end
+
+    it "is invalid without a number" do
+      integration.preferred_password = "ValidPassword@xxxxxxx"
+
+      expect(integration).not_to be_valid
+      expect(integration.errors[:preferred_password]).to be_present
+    end
+  end
+
+  describe "class metadata" do
+    it "belongs to the Shipping integration group" do
+      expect(described_class.integration_group).to eq("Shipping")
+    end
+
+    it "exposes a brand integration name" do
+      expect(described_class.integration_name).to eq(Spree.t("admin.integrations.shipstation.brand_name"))
+    end
+
+    it "points at the ShipStation logo asset" do
+      expect(described_class.icon_path).to eq("integration_icons/shipstation-logo.webp")
+    end
+  end
+end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -31,16 +31,14 @@ RSpec.describe Spree::Shipment do
   end
 
   describe ".exportable" do
-    context "when capture_at_notification is false" do
-      it "returns ONLY ready shipments from complete orders" do
-        ready_shipment = create(:order_ready_to_ship).shipments.first
-        canceled_order = create(:order_ready_to_ship)
-        canceled_order.shipments.first.cancel!
+    it "returns ONLY ready shipments from complete orders" do
+      ready_shipment = create(:order_ready_to_ship).shipments.first
+      canceled_order = create(:order_ready_to_ship)
+      canceled_order.shipments.first.cancel!
 
-        create(:shipped_order)
+      create(:shipped_order)
 
-        expect(described_class.exportable).to eq([ready_shipment])
-      end
+      expect(described_class.exportable).to eq([ready_shipment])
     end
   end
 end

--- a/spec/presenters/spree_shipstation/export/item_presenter_spec.rb
+++ b/spec/presenters/spree_shipstation/export/item_presenter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SpreeShipstation::Export::ItemPresenter do
+  let!(:store) { create(:store, default: true) }
+  let(:order) { create(:order_ready_to_ship, store: store) }
+  let(:shipment) { order.shipments.first }
+  let(:line_item) { shipment.inventory_units.first.line_item }
+  let(:units) { shipment.inventory_units.select { |unit| unit.line_item == line_item } }
+
+  subject(:presenter) { described_class.new(line_item, units) }
+
+  it "exposes the variant sku and unit price" do
+    expect(presenter.sku).to eq(line_item.variant.sku)
+    expect(presenter.unit_price).to eq(line_item.price)
+  end
+
+  it "counts the inventory units as the quantity" do
+    expect(presenter.quantity).to eq(units.size)
+  end
+
+  it "builds a Weight value object from the variant" do
+    expect(presenter.weight).to eq(SpreeShipstation::Export::Weight.from_variant(line_item.variant))
+  end
+
+  describe "#name" do
+    it "joins the product name with the variant options text, dropping blanks" do
+      allow(line_item.variant).to receive(:options_text).and_return("")
+
+      expect(presenter.name).to eq(line_item.variant.product.name)
+    end
+
+    it "includes the options text when present" do
+      allow(line_item.variant).to receive(:options_text).and_return("Size: L")
+
+      expect(presenter.name).to eq("#{line_item.variant.product.name} Size: L")
+    end
+  end
+
+  describe "#image" do
+    it "prefers a variant image, then the master image" do
+      variant_image = double("Image")
+      allow(line_item.variant).to receive(:images).and_return([variant_image])
+
+      expect(presenter.image).to eq(variant_image)
+    end
+
+    it "falls back to the product master image when the variant has none" do
+      master_image = double("Image")
+      allow(line_item.variant).to receive(:images).and_return([])
+      allow(line_item.variant.product.master).to receive(:images).and_return([master_image])
+
+      expect(presenter.image).to eq(master_image)
+    end
+  end
+end

--- a/spec/presenters/spree_shipstation/export/order_presenter_spec.rb
+++ b/spec/presenters/spree_shipstation/export/order_presenter_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SpreeShipstation::Export::OrderPresenter do
+  let!(:store) { create(:store, default: true) }
+  let(:order) { create(:order_ready_to_ship, store: store) }
+  let(:shipment) { order.shipments.first }
+
+  subject(:presenter) { described_class.new(shipment) }
+
+  describe "identifiers and order-level fields" do
+    it "derives the order id and number from the shipment" do
+      expect(presenter.order_id).to eq(shipment.id)
+      expect(presenter.order_number).to eq(shipment.number)
+    end
+
+    it "exposes the shipment state as the order status" do
+      expect(presenter.order_status).to eq(shipment.state)
+    end
+
+    it "exposes order totals and the order number as CustomField1" do
+      expect(presenter.order_total).to eq(order.total)
+      expect(presenter.tax_total).to eq(order.tax_total)
+      expect(presenter.ship_total).to eq(order.ship_total)
+      expect(presenter.custom_field_1).to eq(order.number)
+    end
+
+    it "truncates the customer code (email) to 50 characters" do
+      allow(order).to receive(:email).and_return("#{"a" * 60}@example.com")
+
+      expect(presenter.customer_code.length).to eq(50)
+    end
+  end
+
+  describe "#order_date and #last_modified" do
+    it "formats the completed_at timestamp using the shared date format" do
+      expect(presenter.order_date)
+        .to eq(order.completed_at.strftime(SpreeShipstation::ExportHelper::DATE_FORMAT))
+    end
+
+    it "uses the latest of completed_at and the shipment's updated_at" do
+      latest = [order.completed_at, shipment.updated_at].compact.max
+
+      expect(presenter.last_modified).to eq(latest.strftime(SpreeShipstation::ExportHelper::DATE_FORMAT))
+    end
+  end
+
+  describe "#items" do
+    it "returns an ItemPresenter per line item with a variant" do
+      expect(presenter.items).to all(be_a(SpreeShipstation::Export::ItemPresenter))
+      expect(presenter.items.size).to eq(shipment.inventory_units.group_by(&:line_item).size)
+    end
+
+    it "skips line items without a variant" do
+      line_item = shipment.inventory_units.first.line_item
+      allow_any_instance_of(Spree::LineItem).to receive(:variant).and_return(nil)
+
+      expect(presenter.items).to be_empty
+      expect(line_item).to be_present
+    end
+  end
+end

--- a/spec/presenters/spree_shipstation/export/weight_spec.rb
+++ b/spec/presenters/spree_shipstation/export/weight_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SpreeShipstation::Export::Weight do
+  describe ".from_variant" do
+    def weight_for(weight:, unit:)
+      variant = double("Variant", weight: weight, weight_unit: unit)
+      described_class.from_variant(variant)
+    end
+
+    it "reports pounds for the lb unit" do
+      result = weight_for(weight: 2.5, unit: "lb")
+
+      expect(result.value).to eq(2.5)
+      expect(result.units).to eq("Pounds")
+    end
+
+    it "reports ounces for the oz unit" do
+      result = weight_for(weight: 8, unit: "oz")
+
+      expect(result.value).to eq(8.0)
+      expect(result.units).to eq("Ounces")
+    end
+
+    it "converts kilograms to grams" do
+      result = weight_for(weight: 1.5, unit: "kg")
+
+      expect(result.value).to eq(1500.0)
+      expect(result.units).to eq("Grams")
+    end
+
+    it "defaults unknown units to grams" do
+      result = weight_for(weight: 42, unit: "stone")
+
+      expect(result.value).to eq(42.0)
+      expect(result.units).to eq("Grams")
+    end
+
+    it "treats a nil weight as zero" do
+      result = weight_for(weight: nil, unit: "lb")
+
+      expect(result.value).to eq(0.0)
+      expect(result.units).to eq("Pounds")
+    end
+  end
+
+  describe "value equality" do
+    it "considers two weights with the same value and units equal" do
+      expect(described_class.new(value: 1.0, units: "Pounds"))
+        .to eq(described_class.new(value: 1.0, units: "Pounds"))
+    end
+
+    it "considers weights with different units unequal" do
+      expect(described_class.new(value: 1.0, units: "Pounds"))
+        .not_to eq(described_class.new(value: 1.0, units: "Grams"))
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Address the findings from a thoughtbot-style code audit: add missing test coverage, extract export presenters, and document security and operational behavior. No external behavior changes — the export XML is byte-structurally identical (verified by the XSD schema spec).

## Problem

The audit surfaced several gaps. The integration model's validations had no specs and ShipmentNotice's error and capture branches were untested, leaving the two highest-risk areas unprotected and overall branch coverage low. The export action assembled its eager-load graph and shaping logic inline in the controller and XML builder, the address helper branched on a type flag, and security/performance expectations (HTTPS for Basic Auth, retry idempotency, indexing) were undocumented.

## Solution

Add specs for the integration validations, the ShipmentNotice error paths (ShipmentNotFound, MissingTrackingNumber, PaymentError), the capture and already-shipped branches, controller sad paths, and the version helper. Move the eager-load graph into the exportable scope, introduce OrderPresenter, ItemPresenter, and a Weight value object to lift shaping out of the builder, and split the address helper into bill_address/ship_address. Document the synchronous payment-capture/retry-idempotency design in code, and add README sections on Basic Auth over HTTPS, rate limiting, response-code semantics, and database indexing for the export query.

## Results

Tests: 18 to 73 examples, 0 failures. Line coverage ~89.5% to ~99.5%. StandardRB clean.
